### PR TITLE
11th commit

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -11,7 +11,10 @@ AuthUserFile C:\MAMP\htdocs\TsukubaUniversityNews\.htpasswd
 require valid-user
 </Files>
 
-# ブラウザからの閲覧を拒否する設定方法
-<Files ~ ".(gitignore|htaccess|htpasswd)$">
+# ブラウザからの閲覧を拒否する設定
+<Files ~ ".(gitignore|htaccess|htpasswd|env)$">
+    deny from all
+</Files>
+<Files ~ "(vendor|config|css|iamge|js)$">
     deny from all
 </Files>

--- a/new-password-logic.php
+++ b/new-password-logic.php
@@ -4,32 +4,61 @@ require __DIR__ . '/config/database.php';
 // new-password.phpからフォームが送信された場合
 if (isset($_POST['submit'])){
     $token = filter_var($_POST['token'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+    $createdPassword = filter_var($_POST['createdpassword'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+    $confirmedPassword = filter_var($_POST['confirmedpassword'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+    $pattern = '/\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)(?=.*?[!-\/:-@[-`{-~])[!-~]{8,100}+\z/i';
+
+    //フォームの値確認
+    // パスワードが８文字未満の場合
+    if (strlen($createdPassword) < 8 || strlen($confirmedPassword) < 8){
+        $_SESSION['new_password_error'] = "パスワードは８文字以上で設定してください";
+
+    // パスワードが異なる場合
+    } elseif (!hash_equals($createdPassword, $confirmedPassword)){
+        $_SESSION['new_password_error'] = "パスワードが違います";
+
+    // パスワードに大文字・記号・数字のいずれかが使われていない場合
+    } elseif (preg_match($pattern, $createdPassword) === 0){
+        $_SESSION['new_password_error'] = "パスワードに半角英大文字・小文字・数字・記号が含まれていません";
+    }
+
+    // この時点でエラーがある場合
+    if (isset($_SESSION['new_password_error'])){
+        // new-passwordページに値を渡してリダイレクト
+        $_SESSION['new_password_data'] = $_POST;
+        header('location: '.ROOT_URL.'new-password.php?token='.$token);
+        die();
+
+    } else {
+        // パスワードをハッシュ化
+        $hashed = password_hash($createdPassword, PASSWORD_DEFAULT);
+
         // DBに同じトークンがあるか確認
         $connection = dbconnect();
-        $stmt = $connection->prepare('SELECT user_ID, role_ID, token FROM users WHERE token=? AND is_deleted=1 LIMIT 1');
-        $stmt->bind_param('s', $token);
-        $success = $stmt->execute();
-        $stmt->bind_result($userID, $roleID, $dbToken);
-        $stmt->fetch();
+        $selectStmt = $connection->prepare('SELECT token FROM users WHERE token=? AND is_deleted=0 LIMIT 1');
+        $selectStmt->bind_param('s', $token);
+        $success = $selectStmt->execute();
+        $selectStmt->bind_result($dbToken);
+        $selectStmt->fetch();
 
         // 値取得時にエラーがある場合
-        if ($dbToken === NULL){
+        if (!$success || $dbToken === NULL){
             $_SESSION['new_password_error'] = "無効のURLです";
             header('location: ' . ROOT_URL . 'message.php');
             die();
-        } else {
-            // DBに登録
-            $connection = dbconnect();
-            $stmt = $connection->prepare('UPDATE users SET token=NULL, updated_at=CURRENT_TIMESTAMP(), is_deleted=0 WHERE token=? LIMIT 1');
-        
-            // SQL文の値を変更
-            $stmt->bind_param('s', $dbToken);
-            $success = $stmt->execute();
         }
+
+        // DBに登録
+        $updateStmt = $connection->prepare('UPDATE users SET password=?, token=NULL, updated_at=CURRENT_TIMESTAMP() WHERE token=? AND is_deleted=0 LIMIT 1');
+    
+        // SQL文の値を変更
+        //途中
+        $updateStmt->bind_param('ss', $hashed, $dbToken);
+        $success = $updateStmt->execute();
 
         // 値更新時にエラーがある場合
         if (!$success) {
-            $_SESSION['new_password_error'] = "予期せぬエラーが発生しました";
+            $_SESSION['new_password_error'] = "パスワードを変更できません";
             $_SESSION['new_password_data'] = $_POST;
             header('location: ' . ROOT_URL . 'new-password.php?token=' . $token);
             die();
@@ -39,10 +68,11 @@ if (isset($_POST['submit'])){
             $_SESSION['new_password_success'] = "パスワードを変更しました";
             $_SESSION['user_ID'] = $userID;
             $_SESSION['role_ID'] = $roleID;
-            header('location:' . ROOT_URL . 'message.php');
+            header('location:' . ROOT_URL . 'admin/');
             die();
         }
-    
+    }
+
 // 変更ボタンがクリックされずに画面遷移した場合
 } else {
     header(('location:' . ROOT_URL));

--- a/new-password.php
+++ b/new-password.php
@@ -7,14 +7,14 @@ if (isset($_GET['token'])){
 
     // DBから一致するトークンを持つ投稿者を取得
     $connection = dbconnect();
-    $stmt = $connection->prepare('SELECT email, token FROM users WHERE token=? AND is_deleted=1 LIMIT 1');
+    $stmt = $connection->prepare('SELECT token FROM users WHERE token=? AND is_deleted=0');
     $stmt->bind_param('s', $token);
     $success = $stmt->execute();
-    $stmt->bind_result($email, $dbToken);
+    $stmt->bind_result($dbToken);
     $stmt->fetch();
 
     // DBにトークンが存在しない場合
-    if (!isset($dbToken)){
+    if (!$success || $dbToken === NULL){
         $_SESSION['new_password_error'] = '無効のURLです';
         header('location: ' . ROOT_URL . 'message.php');
         die();
@@ -48,13 +48,22 @@ if (isset($_GET['token'])){
 <body>
     <section class="form__section">
         <div class="container form__section-container">
-            <h2>パスワード変更されたユーザー</h2>
-            <p>「確認」を押してパスワード変更を完了してください</p>
+            <h2>パスワード変更</h2>
+            <!-- パスワード変更に失敗した場合 -->
+            <?php if (isset($_SESSION['new_password_error'])): ?>
+                <div class="alert__message error">
+                    <p>
+                        <?php echo $_SESSION['new_password_error'];
+                        unset($_SESSION['new_password_error']); ?>
+                    </p>
+                </div>
+            <?php endif; ?>
             <!-- 新しいパスワードを登録するフォーム -->
             <form class="form__column" action="<?php echo ROOT_URL ?>new-password-logic.php" method="POST">
                 <input type="hidden" name="token" value="<?php echo $dbToken ?>">
-                <input type="email" name="email" value="<?php echo $email ?>" readonly>
-                <button type="submit" name="submit" class="btn purple">確認</button>
+                <input type="password" name="createdpassword" value="" placeholder="新しいパスワード">
+                <input type="password" name="confirmedpassword" value="" placeholder="新しいパスワード（再入力）">
+                <button type="submit" name="submit" class="btn purple">変更</button>
             </form>        
         </div>
     </section>

--- a/reset-password-logic.php
+++ b/reset-password-logic.php
@@ -9,69 +9,55 @@ date_default_timezone_set('Asia/Tokyo');
 // reset-password.phpのフォームが送信された場合
 if (isset($_POST['submit'])){
     $email = filter_var($_POST['email'], FILTER_VALIDATE_EMAIL);
-    $createdPassword = filter_var($_POST['createdpassword'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-    $confirmedPassword = filter_var($_POST['confirmedpassword'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-    $pattern = '/\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)(?=.*?[!-\/:-@[-`{-~])[!-~]{8,100}+\z/i';
-    $result = preg_match($pattern, $createdPassword);
 
-    //フォームの値確認
-    // パスワードが８文字未満の場合
-    if (strlen($createdPassword) < 8 || strlen($confirmedPassword) < 8){
-        $_SESSION['reset_password_error'] = "パスワードは８文字以上で設定してください";
-    
-    // パスワードが異なる場合
-    } elseif ($createdPassword !== $confirmedPassword){
-        $_SESSION['reset_password_error'] = "パスワードが違います";
-    
-    // パスワードに大文字・記号・数字のいずれかが使われていない場合
-    } elseif ($result === 0) {
-        $_SESSION['reset_password_error'] = "パスワードに半角英大文字・小文字・数字・記号が含まれていません";
+    // DBにメールアドレスが登録されているか確認
+    $connection = dbconnect();
+    $stmt = $connection->prepare('SELECT email FROM users WHERE email=? AND is_deleted=0 LIMIT 1');
+    $stmt->bind_param('s', $email);
+    $stmt->execute();
+    $stmt->bind_result($dbEmail);
+    $stmt->fetch();
+
+    // DBにメールアドレスが登録されていない場合
+    if ($dbEmail === NULL){
+        $_SESSION['reset_password_error'] = "そのメールアドレスは登録されていません";
+        $_SESSION['reset_password_data'] = $_POST;
+        header('location: ' . ROOT_URL . 'reset-password.php');
+        die();
     }
 
-    // この時点でエラーがある場合
-    if (isset($_SESSION['reset_password_error'])){
-        // new-passwordページに値を渡してリダイレクト
+    // URL用のトークンを生成
+    $token = bin2hex(random_bytes(32));
+
+    // DBにトークンを登録
+    $connection = dbconnect();
+    $stmt = $connection->prepare('UPDATE users SET token=?, updated_at=CURRENT_TIMESTAMP() WHERE email=? AND is_deleted=0 LIMIT 1');
+    $stmt->bind_param('ss', $token, $dbEmail);
+    $success = $stmt->execute();
+
+    // エラーがある場合
+    if (!$success){
+        $_SESSION['reset_password_error'] = "パスワードを変更できません";
         $_SESSION['reset_password_data'] = $_POST;
-        header('location: '.ROOT_URL.'reset-password.php');
+        header('location: ' . ROOT_URL . 'reset-password.php');
         die();
-        
+
+    // エラーがない場合
     } else {
-        // URL用のトークンを生成
-        $token = bin2hex(random_bytes(32));
-
-        // DBにトークンを登録
-        $connection = dbconnect();
-        $stmt = $connection->prepare('UPDATE users SET token=?, updated_at=CURRENT_TIMESTAMP(), is_deleted=1 WHERE email=? AND is_deleted=0 LIMIT 1');
-        if (!$stmt){
-            die($connection->error);
-        }
-        $stmt->bind_param('ss', $token, $email);
-        $success = $stmt->execute();
-
-        // エラーがある場合
-        if (!$success){
-            $_SESSION['reset_password_error'] = "パスワードを変更できません";
-            $_SESSION['reset_password_data'] = $_POST;
-            header('location: ' . ROOT_URL . 'reset-password.php');
-            die();
-
-        // エラーがない場合
-        } else {
-            $_SESSION['reset_password_success'] = "確認メールを送信しました。登録済みのメールアドレスを確認してください";
-            header('location:' . ROOT_URL . 'message.php');
-
-            // パスワード変更用メールを送るための設定
-            // メールタイトル
-            $autoReplyTitle = 'パスワード変更 | Tsukuba University News';
-            // メール本文
-            $autoReplyBody = "パスワードが変更されました。下記URLにアクセスしてください。\n";
-            $autoReplyBody .= "http://localhost:8888/TsukubaUniversityNews/new-password.php?token=" . $token . "\n\n";
-            $autoReplyBody .= "Tsukuba University News";
-            // ヘッダー
-            $header = "From: Tsukuba University News <name@gmail.com>\n";
-            // 送信
-            mb_send_mail($email, $autoReplyTitle, $autoReplyBody, $header);
-        }
+        $_SESSION['reset_password_success'] = "パスワード変更用のURLを送信しました。登録済みのメールアドレスを確認してください";
+        header('location:' . ROOT_URL . 'message.php');
+        
+        // パスワード変更用メールを送るための設定
+        // メールタイトル
+        $autoReplyTitle = 'パスワード変更 | Tsukuba University News';
+        // メール本文
+        $autoReplyBody = "下記URLから新しいパスワードを設定してください\n";
+        $autoReplyBody .= "http://localhost:8888/TsukubaUniversityNews/new-password.php?token=" . $token . "\n\n";
+        $autoReplyBody .= "Tsukuba University News";
+        // ヘッダー
+        $header = "From: Tsukuba University News <name@gmail.com>\n";
+        // 送信
+        mb_send_mail($email, $autoReplyTitle, $autoReplyBody, $header);
     }
 
 // reset-password.phpのフォームが送信されていない場合

--- a/reset-password.php
+++ b/reset-password.php
@@ -30,7 +30,7 @@ unset($_SESSION['reset_password_data']);
     <section class="form__section">
         <div class="container form__section-container">
             <h2>パスワード変更</h2>
-            <!-- メール送信できなかった場合 -->
+            <!-- 一致するメールアドレスが存在しない時 -->
             <?php if (isset($_SESSION['reset_password_error'])): ?>
                 <div class="alert__message error">
                     <p>
@@ -42,9 +42,7 @@ unset($_SESSION['reset_password_data']);
             <!-- パスワードリセット用のフォーム -->
             <form class="form__column" action="<?php echo ROOT_URL ?>reset-password-logic.php" method="POST">
                 <input type="email" name="email" value="<?php echo h($email) ?>" placeholder="メールアドレス">
-                <input type="password" name="createdpassword" value="" placeholder="新しいパスワード">
-                <input type="password" name="confirmedpassword" value="" placeholder="新しいパスワード（再入力）">
-                <button type="submit" name="submit" class="btn purple">変更</button>
+                <button type="submit" name="submit" class="btn purple">確認</button>
             </form>        
         </div>
     </section>

--- a/signup-logic.php
+++ b/signup-logic.php
@@ -7,7 +7,6 @@ if (isset($_POST['submit'])){
     $createdPassword = filter_var($_POST['createdpassword'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
     $confirmedPassword = filter_var($_POST['confirmedpassword'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
     $pattern = '/\A(?=.*?[a-z])(?=.*?[A-Z])(?=.*?\d)(?=.*?[!-\/:-@[-`{-~])[!-~]{8,100}+\z/i';
-    $result = preg_match($pattern, $createdPassword);
 
     //フォームの値確認
     // メールアドレスが空の場合
@@ -19,11 +18,11 @@ if (isset($_POST['submit'])){
         $_SESSION['signup_error'] = "パスワードは８文字以上で設定してください";
     
     // パスワードが異なる場合
-    } elseif ($createdPassword !== $confirmedPassword){
+    } elseif (!hash_equals($createdPassword, $confirmedPassword)){
         $_SESSION['signup_error'] = "パスワードが違います";
     
     // パスワードに大文字・記号・数字のいずれかが使われていない場合
-    } elseif ($result === 0) {
+    } elseif (preg_match($pattern, $createdPassword) === 0) {
         $_SESSION['signup_error'] = "パスワードに半角英大文字・小文字・数字・記号が含まれていません";
     
     // フォームに全ての値が入力されている場合


### PR DESCRIPTION
## 取り組んだこと
### feat
- new-password.php, new-password-logic.php, reset-password.php, reset-password-logic.phpのロジックを元に戻した。メールアドレス確認→トークンを生成・保存→メール送信
### fix
- 存在しないURLからnew-password.phpでパスワードを登録した場合にメッセージを表示
### refactor
- .htaccessでブラウザからの閲覧拒否ファイルを追加
- singup-logic.php, new-password-logic.phpでのパスワード比較方法変更
- reset-password-logic.phpでメールアドレスが登録されていないときの動作変更